### PR TITLE
Fix handle cold starts and completion handlers

### DIFF
--- a/RNNotificationActions/RNNotificationActions.h
+++ b/RNNotificationActions/RNNotificationActions.h
@@ -4,8 +4,6 @@
 
 @interface RNNotificationActions : NSObject <RCTBridgeModule>
 
-@property NSMutableDictionary *completeCallbacks;
-
 + (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;
 + (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;
 

--- a/RNNotificationActions/RNNotificationActions.m
+++ b/RNNotificationActions/RNNotificationActions.m
@@ -1,5 +1,6 @@
 @import UIKit;
 #import "RNNotificationActions.h"
+#import "RNNotificationActionsManager.h"
 
 #import "RCTBridge.h"
 #import "RCTConvert.h"
@@ -41,7 +42,6 @@ RCT_EXPORT_MODULE();
 - (id)init
 {
     if (self = [super init]) {
-        self.completeCallbacks = [[NSMutableDictionary alloc] init];
         return self;
     } else {
         return nil;
@@ -61,6 +61,13 @@ RCT_EXPORT_MODULE();
                                              selector:@selector(handleNotificationActionReceived:)
                                                  name:RNNotificationActionReceived
                                                object:nil];
+    NSDictionary *lastActionInfo = [RNNotificationActionsManager sharedInstance].lastActionInfo;
+    if(lastActionInfo != nil) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationActionReceived
+                                                            object:self
+                                                          userInfo:lastActionInfo];
+        [RNNotificationActionsManager sharedInstance].lastActionInfo = nil;
+    }
 }
 
 - (UIMutableUserNotificationAction *)actionFromJSON:(NSDictionary *)opts
@@ -111,20 +118,28 @@ RCT_EXPORT_METHOD(updateCategories:(NSArray *)json)
     [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:types categories:[NSSet setWithArray:categories]]];
 }
 
+RCT_EXPORT_METHOD(callCompletionHandler)
+{
+    void (^completionHandler)() = [RNNotificationActionsManager sharedInstance].lastCompletionHandler;
+    if(completionHandler != nil) {
+        completionHandler();
+        [RNNotificationActionsManager sharedInstance].lastCompletionHandler = nil;
+    }
+}
+
+
 // Handle notifications received by the app delegate and passed to the following class methods
 + (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;
 {
-    [self emitNotificationActionForIdentifier:identifier source:@"local" responseInfo:responseInfo userInfo:notification.userInfo];
-    completionHandler();
+    [self emitNotificationActionForIdentifier:identifier source:@"local" responseInfo:responseInfo userInfo:notification.userInfo completionHandler:completionHandler];
 }
 
 + (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
 {
-    [self emitNotificationActionForIdentifier:identifier source:@"remote" responseInfo:responseInfo userInfo:userInfo];
-    completionHandler();
+    [self emitNotificationActionForIdentifier:identifier source:@"remote" responseInfo:responseInfo userInfo:userInfo completionHandler:completionHandler];
 }
 
-+ (void)emitNotificationActionForIdentifier:(NSString *)identifier source:(NSString *)source responseInfo:(NSDictionary *)responseInfo userInfo:(NSDictionary *)userInfo
++ (void)emitNotificationActionForIdentifier:(NSString *)identifier source:(NSString *)source responseInfo:(NSDictionary *)responseInfo userInfo:(NSDictionary *)userInfo completionHandler:(void (^)())completionHandler
 {
     NSMutableDictionary *info = [[NSMutableDictionary alloc] initWithDictionary:@{
                                                                                   @"identifier": identifier,
@@ -144,6 +159,8 @@ RCT_EXPORT_METHOD(updateCategories:(NSArray *)json)
     [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationActionReceived
                                                         object:self
                                                       userInfo:info];
+    [RNNotificationActionsManager sharedInstance].lastActionInfo = info;
+    [RNNotificationActionsManager sharedInstance].lastCompletionHandler = completionHandler;
 }
 
 - (void)handleNotificationActionReceived:(NSNotification *)notification

--- a/RNNotificationActions/RNNotificationActions.xcodeproj/project.pbxproj
+++ b/RNNotificationActions/RNNotificationActions.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5D1251B41CB6130700A4BC7A /* RNNotificationActionsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D1251B31CB6130700A4BC7A /* RNNotificationActionsManager.m */; };
 		E2B7F23D1C36E76100945232 /* RNNotificationActions.m in Sources */ = {isa = PBXBuildFile; fileRef = E2B7F23C1C36E76100945232 /* RNNotificationActions.m */; };
 /* End PBXBuildFile section */
 
@@ -23,6 +24,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5D1251B21CB6130700A4BC7A /* RNNotificationActionsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNotificationActionsManager.h; sourceTree = SOURCE_ROOT; };
+		5D1251B31CB6130700A4BC7A /* RNNotificationActionsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNotificationActionsManager.m; sourceTree = SOURCE_ROOT; };
 		E2B7F22F1C36E6D800945232 /* libRNNotificationActions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNNotificationActions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2B7F23B1C36E76100945232 /* RNNotificationActions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNotificationActions.h; sourceTree = SOURCE_ROOT; };
 		E2B7F23C1C36E76100945232 /* RNNotificationActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNotificationActions.m; sourceTree = SOURCE_ROOT; };
@@ -60,6 +63,8 @@
 			children = (
 				E2B7F23B1C36E76100945232 /* RNNotificationActions.h */,
 				E2B7F23C1C36E76100945232 /* RNNotificationActions.m */,
+				5D1251B21CB6130700A4BC7A /* RNNotificationActionsManager.h */,
+				5D1251B31CB6130700A4BC7A /* RNNotificationActionsManager.m */,
 			);
 			path = RNNotificationActions;
 			sourceTree = "<group>";
@@ -120,6 +125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D1251B41CB6130700A4BC7A /* RNNotificationActionsManager.m in Sources */,
 				E2B7F23D1C36E76100945232 /* RNNotificationActions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RNNotificationActions/RNNotificationActionsManager.h
+++ b/RNNotificationActions/RNNotificationActionsManager.h
@@ -1,0 +1,17 @@
+//
+//  RNNotificationActionsManager.h
+//
+//  Created by Joel Arvidsson on 2016-04-06.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RNNotificationActionsManager : NSObject
+
+@property (nonatomic, retain) NSDictionary *lastActionInfo;
+@property (nonatomic, copy) void (^lastCompletionHandler)();
+
++ (nonnull instancetype)sharedInstance;
+
+@end

--- a/RNNotificationActions/RNNotificationActionsManager.m
+++ b/RNNotificationActions/RNNotificationActionsManager.m
@@ -1,0 +1,21 @@
+//
+//  RNNotificationActionsManager.m
+//
+//  Created by Joel Arvidsson on 2016-04-06.
+//
+//
+
+#import "RNNotificationActionsManager.h"
+
+@implementation RNNotificationActionsManager
+
++ (nonnull instancetype)sharedInstance {
+    static RNNotificationActionsManager *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [self new];
+    });
+    return sharedInstance;
+}
+
+@end

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,10 +1,10 @@
-import {NativeModules, NativeAppEventEmitter} from 'react-native';
-const {RNNotificationActions} = NativeModules;
+import { NativeModules, NativeAppEventEmitter } from 'react-native';
+const { RNNotificationActions } = NativeModules;
 
 let actions = {};
 
-todoComplete = () => {
-  console.info('TODO - implement complete callbacks for objective-c (the callback was already called in this case)');
+function handleActionCompleted() {
+  RNNotificationActions.callCompletionHandler();
 };
 
 export class Action {
@@ -17,8 +17,7 @@ export class Action {
     actions[opts.identifier] = this;
     NativeAppEventEmitter.addListener('notificationActionReceived', (body) => {
       if (body.identifier === opts.identifier) {
-        //console.info('got action interaction!', body);
-        onComplete(body, todoComplete);
+        onComplete(body, handleActionCompleted);
       }
     });
   }
@@ -34,19 +33,15 @@ export class Category {
 }
 
 export const updateCategories = (categories) => {
-  //console.info('updating categories!', categories);
-  //console.info(RNNotificationActions);
-  //RNNotificationActions.logTest('heyooO!');
   let cats = categories.map((cat) => {
     return Object.assign({}, cat.opts, {
       actions: cat.opts.actions.map((action) => action.opts)
-    })
+    });
   });
-  //console.info('updating categories', cats);
+
   RNNotificationActions.updateCategories(cats);
   // Re-update when permissions change
   NativeAppEventEmitter.addListener('remoteNotificationsRegistered', () => {
-    //console.info('updating notification categories in response to permission change');
     RNNotificationActions.updateCategories(cats);
   });
 };


### PR DESCRIPTION
Related issue #3. Tried suggested fix in that issue but that didn't solve cold starts and only made the app crash when done handler was called. 

Since the bridge is not initialized when the interactive notification handler is called from a cold start (which I would imagine is by far the most common scenario) the notifications never reach the JS side. This PR fixes that by temporarily storing them in a singleton and also takes care of calling the completion block once finished which should solve those cases when the app is killed before the action is really performed. 
